### PR TITLE
Add settings to configure and disable encryption

### DIFF
--- a/src/credentials_obfuscation.app.src
+++ b/src/credentials_obfuscation.app.src
@@ -11,7 +11,8 @@
     crypto
    ]},
   {env,[
-      {ets_table_name, credentials_obfuscation}
+      {ets_table_name, credentials_obfuscation},
+      {enabled, true}
   ]},
   {modules, []}
  ]}.

--- a/src/credentials_obfuscation.erl
+++ b/src/credentials_obfuscation.erl
@@ -21,13 +21,23 @@
 encrypt(none) ->
     none;
 encrypt(Term) ->
-    credentials_obfuscation_pbe:encrypt(
-        credentials_obfuscation_pbe:default_cipher(), credentials_obfuscation_pbe:default_hash(), credentials_obfuscation_pbe:default_iterations(), 
-        credentials_obfuscation_app:passphrase(), Term).
+    case credentials_obfuscation_app:enabled() of
+        true ->
+            credentials_obfuscation_pbe:encrypt(
+                credentials_obfuscation_app:cipher(), credentials_obfuscation_app:hash(), credentials_obfuscation_app:iterations(),
+                credentials_obfuscation_app:passphrase(), Term);
+        false ->
+            Term
+    end.
 
 decrypt(none) ->
     none;
 decrypt(Base64EncryptedBinary) ->
-    credentials_obfuscation_pbe:decrypt(
-        credentials_obfuscation_pbe:default_cipher(), credentials_obfuscation_pbe:default_hash(), credentials_obfuscation_pbe:default_iterations(), 
-        credentials_obfuscation_app:passphrase(), Base64EncryptedBinary).
+    case credentials_obfuscation_app:enabled() of
+        true ->
+            credentials_obfuscation_pbe:decrypt(
+                credentials_obfuscation_app:cipher(), credentials_obfuscation_app:hash(), credentials_obfuscation_app:iterations(), 
+                credentials_obfuscation_app:passphrase(), Base64EncryptedBinary);
+        false ->
+            Base64EncryptedBinary
+    end.


### PR DESCRIPTION
This commit adds options to configure the encryption (cipher, hash, and
number of iterations) and to disable it all together. This way the
feature can be disabled in applications like the Erlang AMQP 0-9-1 client or
Federation if it makes them unstable or crash (at the cost of losing the
credentials obfuscation). This seems like a reasonable trade-off while the
feature is being integrated in the system.

There is also now an encryption/decryption attempt on application startup to
crash early in case of a problem instead of crashing at an awkward moment,
e.g. when a Shovel or Federation link starts.

[#167149046]