### PR TITLE
Version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ the Erlang runtime (`error_logger`).
 Note that this application **cannot protect against heap dumping attacks** and only helps
 avoid sensitive data appearing in log files.
 
+# Usage
+
+First, make the `credentials_obfuscation` application a dependency of your project.
+
+Then, during the start-up of your application, and after the `credentials_obfuscation` application starts, provide the secret value:
+
+
+```
+CookieBin = atom_to_binary(erlang:get_cookie(), latin1)),
+credentials_obfuscation:set_secret(CookieBin)
+```
+
 ## License and Copyright
 
 See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ CookieBin = atom_to_binary(erlang:get_cookie(), latin1)),
 credentials_obfuscation:set_secret(CookieBin)
 ```
 
+To use a random value, do the following:
+
+```
+Bytes = crypto:strong_rand_bytes(128),
+credentials_obfuscation:set_secret(Bytes)
+```
+
 ## License and Copyright
 
 See [LICENSE](./LICENSE).

--- a/include/credentials_obfuscation.hrl
+++ b/include/credentials_obfuscation.hrl
@@ -1,0 +1,1 @@
+-define(PENDING_SECRET, '$pending-secret').

--- a/src/credentials_obfuscation.app.src
+++ b/src/credentials_obfuscation.app.src
@@ -1,11 +1,17 @@
-{application,credentials_obfuscation,
-             [{description,"Helper library that obfuscates sensitive values in process state"},
-              {vsn,"1.2.0"},
-              {licenses,["MPL1.1","ASL2"]},
-              {links,[{"GitHub",
-                       "https://github.com/rabbitmq/credentials-obfuscation"}]},
-              {registered,[]},
-              {mod,{credentials_obfuscation_app,[]}},
-              {applications,[kernel,stdlib,crypto]},
-              {env,[{ets_table_name,credentials_obfuscation},{enabled,true}]},
-              {modules,[]}]}.
+{application, credentials_obfuscation, [
+    {description, "Helper library that obfuscates sensitive values in process state"},
+    {vsn, "1.2.0"},
+    {licenses, ["MPL1.1", "ASL2"]},
+    {links, [
+        {"GitHub", "https://github.com/rabbitmq/credentials-obfuscation"}
+    ]},
+    {registered, []},
+    {mod, {credentials_obfuscation_app, []}},
+    {applications, [kernel, stdlib, crypto]},
+    {env, [
+        {enabled, true},
+        {secret, cookie},
+        {ets_table_name, credentials_obfuscation}
+    ]},
+    {modules,[]}
+]}.

--- a/src/credentials_obfuscation.app.src
+++ b/src/credentials_obfuscation.app.src
@@ -9,8 +9,7 @@
     {mod, {credentials_obfuscation_app, []}},
     {applications, [kernel, stdlib, crypto]},
     {env, [
-        {enabled, true},
-        {ets_table_name, credentials_obfuscation}
+        {enabled, true}
     ]},
     {modules,[]}
 ]}.

--- a/src/credentials_obfuscation.app.src
+++ b/src/credentials_obfuscation.app.src
@@ -1,6 +1,6 @@
 {application, credentials_obfuscation, [
     {description, "Helper library that obfuscates sensitive values in process state"},
-    {vsn, "1.2.0"},
+    {vsn, "2.0.0"},
     {licenses, ["MPL1.1", "ASL2"]},
     {links, [
         {"GitHub", "https://github.com/rabbitmq/credentials-obfuscation"}
@@ -10,7 +10,6 @@
     {applications, [kernel, stdlib, crypto]},
     {env, [
         {enabled, true},
-        {secret, cookie},
         {ets_table_name, credentials_obfuscation}
     ]},
     {modules,[]}

--- a/src/credentials_obfuscation.erl
+++ b/src/credentials_obfuscation.erl
@@ -22,24 +22,29 @@
 %% API
 -export([set_secret/1, encrypt/1, decrypt/1, refresh_config/0]).
 
+-spec enabled() -> boolean().
 enabled() ->
     credentials_obfuscation_svc:get_config(enabled).
 
+-spec cipher() -> atom().
 cipher() ->
     credentials_obfuscation_svc:get_config(cipher).
 
+-spec hash() -> atom().
 hash() ->
     credentials_obfuscation_svc:get_config(hash).
 
+-spec iterations() -> non_neg_integer().
 iterations() ->
     credentials_obfuscation_svc:get_config(iterations).
 
+-spec secret() -> binary() | '$pending-secret'.
 secret() ->
     credentials_obfuscation_svc:get_config(secret).
 
 -spec set_secret(binary()) -> ok.
 set_secret(Secret) when is_binary(Secret) ->
-    credentials_obfuscation_svc:set_secret(Secret).
+    ok = credentials_obfuscation_svc:set_secret(Secret).
 
 -spec encrypt(term()) -> {plaintext, term()} | {encrypted, binary()}.
 encrypt(none) -> none;

--- a/src/credentials_obfuscation.erl
+++ b/src/credentials_obfuscation.erl
@@ -20,7 +20,7 @@
 -export([enabled/0, cipher/0, hash/0, iterations/0, secret/0]).
 
 %% API
--export([set_secret/1, encrypt/1, decrypt/1]).
+-export([set_secret/1, encrypt/1, decrypt/1, refresh_config/0]).
 
 enabled() ->
     credentials_obfuscation_svc:get_config(enabled).
@@ -52,3 +52,7 @@ decrypt(none) -> none;
 decrypt(undefined) -> undefined;
 decrypt(Term) ->
     credentials_obfuscation_svc:decrypt(Term).
+
+-spec refresh_config() -> ok.
+refresh_config() ->
+    credentials_obfuscation_svc:refresh_config().

--- a/src/credentials_obfuscation.erl
+++ b/src/credentials_obfuscation.erl
@@ -16,28 +16,39 @@
 
 -module(credentials_obfuscation).
 
--export([encrypt/1,decrypt/1]).
+%% Configuration API
+-export([enabled/0, cipher/0, hash/0, iterations/0, secret/0]).
 
+%% API
+-export([set_secret/1, encrypt/1, decrypt/1]).
+
+enabled() ->
+    credentials_obfuscation_svc:get_config(enabled).
+
+cipher() ->
+    credentials_obfuscation_svc:get_config(cipher).
+
+hash() ->
+    credentials_obfuscation_svc:get_config(hash).
+
+iterations() ->
+    credentials_obfuscation_svc:get_config(iterations).
+
+secret() ->
+    credentials_obfuscation_svc:get_config(secret).
+
+-spec set_secret(binary()) -> ok.
+set_secret(Secret) when is_binary(Secret) ->
+    credentials_obfuscation_svc:set_secret(Secret).
+
+-spec encrypt(term()) -> {plaintext, term()} | {encrypted, binary()}.
 encrypt(none) -> none;
 encrypt(undefined) -> undefined;
 encrypt(Term) ->
-    case credentials_obfuscation_app:enabled() of
-        true ->
-            credentials_obfuscation_pbe:encrypt(
-                credentials_obfuscation_app:cipher(), credentials_obfuscation_app:hash(), credentials_obfuscation_app:iterations(),
-                credentials_obfuscation_app:secret(), Term);
-        false ->
-            Term
-    end.
+    credentials_obfuscation_svc:encrypt(Term).
 
+-spec decrypt({plaintext, term()} | {encrypted, binary()}) -> term().
 decrypt(none) -> none;
 decrypt(undefined) -> undefined;
-decrypt(Base64EncryptedBinary) ->
-    case credentials_obfuscation_app:enabled() of
-        true ->
-            credentials_obfuscation_pbe:decrypt(
-                credentials_obfuscation_app:cipher(), credentials_obfuscation_app:hash(), credentials_obfuscation_app:iterations(), 
-                credentials_obfuscation_app:secret(), Base64EncryptedBinary);
-        false ->
-            Base64EncryptedBinary
-    end.
+decrypt(Term) ->
+    credentials_obfuscation_svc:decrypt(Term).

--- a/src/credentials_obfuscation_app.erl
+++ b/src/credentials_obfuscation_app.erl
@@ -20,78 +20,8 @@
 
 -export([start/2, stop/1]).
 
-%% Dummy supervisor - see Ulf Wiger's comment at
-%% http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html
--behaviour(supervisor).
--export([init/1]).
-
--export([enabled/0, secret/0, cipher/0, hash/0, iterations/0]).
-
 start(_StartType, _StartArgs) ->
-    ok = case enabled() of
-             true ->
-                 Secret = get_secret(),
-                 T = ets:new(table_name(), [set, public, named_table]),
-                 ets:insert_new(T, {secret, Secret}),
-                 %% cipher/decipher attempt to crash now instead of at some awkward moment
-                 check();
-             false ->
-                 ok
-         end,
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
-
-check() ->
-    Value = <<"dummy">>,
-    Encrypted = credentials_obfuscation:encrypt(Value),
-    Value = credentials_obfuscation:decrypt(Encrypted),
-    ok.
+    credentials_obfuscation_sup:start_link().
 
 stop(_State) ->
     ok.
-
-init([]) ->
-    {ok, {{one_for_one, 1, 5}, []}}.
-
-enabled() ->
-    application:get_env(credentials_obfuscation, enabled, true).
-
-secret() ->
-    maybe_update_secret(ets:lookup(table_name(), secret)).
-
-table_name() ->
-    application:get_env(credentials_obfuscation, ets_table_name, credentials_obfuscation).
-
-cipher() ->
-    application:get_env(credentials_obfuscation, cipher, credentials_obfuscation_pbe:default_cipher()).
-
-hash() ->
-    application:get_env(credentials_obfuscation, hash, credentials_obfuscation_pbe:default_hash()).
-
-iterations() ->
-    application:get_env(credentials_obfuscation, iterations, credentials_obfuscation_pbe:default_iterations()).
-
-maybe_update_secret([{secret, '$pending-secret'=Pending}]) ->
-    case get_secret() of
-        Pending ->
-            Pending;
-        UpdatedSecret ->
-            ets:insert(table_name(), {secret, UpdatedSecret}),
-            UpdatedSecret
-    end;
-maybe_update_secret([{secret, Secret}]) ->
-    Secret.
-
-get_secret() ->
-    case application:get_env(credentials_obfuscation, secret) of
-        {ok, cookie} ->
-            case erlang:get_cookie() of
-                nocookie ->
-                    '$pending-secret';
-                Cookie ->
-                    atom_to_binary(Cookie, utf8)
-            end;
-        {ok, PredefinedSecret} when is_binary(PredefinedSecret) ->
-            PredefinedSecret;
-        undefined ->
-            crypto:strong_rand_bytes(128)
-    end.

--- a/src/credentials_obfuscation_app.erl
+++ b/src/credentials_obfuscation_app.erl
@@ -20,8 +20,10 @@
 
 -export([start/2, stop/1]).
 
+-spec start(_,_) -> {'error', _} | {'ok', pid()} | {'ok', pid(), _}.
 start(_StartType, _StartArgs) ->
     credentials_obfuscation_sup:start_link().
 
+-spec stop(_) -> 'ok'.
 stop(_State) ->
     ok.

--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -117,9 +117,9 @@ encrypt(Cipher, Hash, Iterations, Secret, ClearText) when is_binary(ClearText) -
     {encrypted, Encrypted}.
 
 -spec decrypt(crypto:block_cipher(), crypto:hash_algorithms(),
-              pos_integer(), iodata(), binary()) -> binary().
-decrypt(_Cipher, _Hash, _Iterations, _Secret, {plaintext, Binary}) ->
-    Binary;
+              pos_integer(), iodata(), {'encrypted', binary() | [1..255]} | {'plaintext', _}) -> any().
+decrypt(_Cipher, _Hash, _Iterations, _Secret, {plaintext, ClearText}) ->
+    ClearText;
 decrypt(Cipher, Hash, Iterations, Secret, {encrypted, Base64Binary}) ->
     IvLength = iv_length(Cipher),
     << Salt:16/binary, Ivec:IvLength/binary, Binary/bits >> = base64:decode(Base64Binary),

--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -16,6 +16,8 @@
 
 -module(credentials_obfuscation_pbe).
 
+-include("credentials_obfuscation.hrl").
+
 -export([supported_ciphers/0, supported_hashes/0, default_cipher/0, default_hash/0, default_iterations/0]).
 -export([encrypt_term/5, decrypt_term/5]).
 -export([encrypt/5, decrypt/5]).
@@ -84,7 +86,7 @@ default_iterations() ->
 
 %% Encryption/decryption of arbitrary Erlang terms.
 
-encrypt_term(_Cipher, _Hash, _Iterations, '$pending-secret', Term) ->
+encrypt_term(_Cipher, _Hash, _Iterations, ?PENDING_SECRET, Term) ->
     {plaintext, Term};
 encrypt_term(Cipher, Hash, Iterations, Secret, Term) ->
     encrypt(Cipher, Hash, Iterations, Secret, term_to_binary(Term)).
@@ -104,7 +106,7 @@ decrypt_term(Cipher, Hash, Iterations, Secret, Base64Binary) ->
 
 -spec encrypt(crypto:block_cipher(), crypto:hash_algorithms(),
               pos_integer(), iodata(), binary()) -> {plaintext, binary()} | {encrypted, binary()}.
-encrypt(_Cipher, _Hash, _Iterations, '$pending-secret', ClearText) ->
+encrypt(_Cipher, _Hash, _Iterations, ?PENDING_SECRET, ClearText) ->
     {plaintext, ClearText};
 encrypt(Cipher, Hash, Iterations, Secret, ClearText) when is_binary(ClearText) ->
     Salt = crypto:strong_rand_bytes(16),

--- a/src/credentials_obfuscation_sup.erl
+++ b/src/credentials_obfuscation_sup.erl
@@ -1,0 +1,48 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(credentials_obfuscation_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init([]) ->
+    SupFlags = #{
+      strategy => one_for_one,
+      intensity => 1,
+      period => 5
+     },
+    ChildSpec = #{
+      id => credentials_obfuscaton_svc,
+      start => {credentials_obfuscation_svc, start_link, []}
+     },
+    {ok, {SupFlags, [ChildSpec]}}.

--- a/src/credentials_obfuscation_sup.erl
+++ b/src/credentials_obfuscation_sup.erl
@@ -28,6 +28,7 @@
 %% API functions
 %% ===================================================================
 
+-spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 

--- a/src/credentials_obfuscation_svc.erl
+++ b/src/credentials_obfuscation_svc.erl
@@ -1,0 +1,129 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(credentials_obfuscation_svc).
+
+-behaviour(gen_server).
+
+-include("credentials_obfuscation.hrl").
+
+%% API functions
+-export([start_link/0, get_config/1,  set_secret/1, encrypt/1, decrypt/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {enabled :: boolean(),
+                cipher :: atom(),
+                hash :: atom(),
+                iterations :: non_neg_integer(),
+                secret :: binary() | '$pending-secret'}).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec get_config(atom()) -> term().
+get_config(Config) ->
+    gen_server:call(?MODULE, {get_config, Config}).
+
+-spec set_secret(binary()) -> ok.
+set_secret(Secret) when is_binary(Secret) ->
+    gen_server:call(?MODULE, {set_secret, Secret}).
+
+-spec encrypt(term()) -> {plaintext, term()} | {encrypted, binary()}.
+encrypt(Term) ->
+    gen_server:call(?MODULE, {encrypt, Term}).
+
+-spec decrypt({plaintext, term()} | {encrypted, binary()}) -> term().
+decrypt(Term) ->
+    gen_server:call(?MODULE, {decrypt, Term}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    State = init_state(),
+    {ok, State}.
+
+handle_call({get_config, enabled}, _From, #state{enabled=Enabled}=State) ->
+    {reply, Enabled, State};
+handle_call({get_config, cipher}, _From, #state{cipher=Cipher}=State) ->
+    {reply, Cipher, State};
+handle_call({get_config, hash}, _From, #state{hash=Hash}=State) ->
+    {reply, Hash, State};
+handle_call({get_config, iterations}, _From, #state{iterations=Iterations}=State) ->
+    {reply, Iterations, State};
+handle_call({get_config, secret}, _From, #state{secret=Secret}=State) ->
+    {reply, Secret, State};
+handle_call({_Request, Term}, _From, #state{enabled=false}=State) ->
+    {reply, Term, State};
+handle_call({encrypt, Term}, _From, #state{cipher=Cipher,
+                                           hash=Hash,
+                                           iterations=Iterations,
+                                           secret=Secret}=State) ->
+    Encrypted = credentials_obfuscation_pbe:encrypt(Cipher, Hash, Iterations, Secret, Term),
+    {reply, Encrypted, State};
+handle_call({decrypt, Term}, _From, #state{cipher=Cipher,
+                                           hash=Hash,
+                                           iterations=Iterations,
+                                           secret=Secret}=State) ->
+    Decrypted = credentials_obfuscation_pbe:decrypt(Cipher, Hash, Iterations, Secret, Term),
+    {reply, Decrypted, State};
+handle_call({set_secret, Secret}, _From, State0) ->
+    State1 = State0#state{secret = Secret},
+    {reply, ok, State1}.
+
+handle_cast(_Message, State) ->
+    {noreply, State}.
+
+handle_info(_Message, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+-spec init_state() -> #state{}.
+init_state() ->
+    Enabled = application:get_env(credentials_obfuscation, enabled, true),
+    Cipher = application:get_env(credentials_obfuscation, cipher,
+                                 credentials_obfuscation_pbe:default_cipher()),
+    Hash = application:get_env(credentials_obfuscation, hash,
+                               credentials_obfuscation_pbe:default_hash()),
+    Iterations = application:get_env(credentials_obfuscation, iterations,
+                                     credentials_obfuscation_pbe:default_iterations()),
+    ok = check(Cipher, Hash, Iterations),
+    #state{enabled = Enabled, cipher = Cipher, hash = Hash,
+           iterations = Iterations, secret = ?PENDING_SECRET}.
+
+check(Cipher, Hash, Iterations) ->
+    Value = <<"dummy">>,
+    TempSecret = crypto:strong_rand_bytes(128),
+    E = credentials_obfuscation_pbe:encrypt(Cipher, Hash, Iterations, TempSecret, Value),
+    Value = credentials_obfuscation_pbe:decrypt(Cipher, Hash, Iterations, TempSecret, E),
+    ok.

--- a/test/credentials_obfuscation_SUITE.erl
+++ b/test/credentials_obfuscation_SUITE.erl
@@ -23,7 +23,7 @@
 all() -> [encrypt_decrypt,
           use_predefined_secret,
           use_cookie_as_secret,
-          encryption_happens_only_when_cookie_available,
+          encryption_happens_only_when_secret_available,
           change_default_cipher,
           disabled,
           application_failure_for_invalid_cipher].
@@ -39,8 +39,8 @@ init_per_testcase(use_predefined_secret, Config) ->
 init_per_testcase(use_cookie_as_secret, Config) ->
     ok = application:set_env(credentials_obfuscation, secret, cookie),
     Config;
-init_per_testcase(encryption_happens_only_when_cookie_available, Config) ->
-    ok = application:set_env(credentials_obfuscation, secret, cookie),
+init_per_testcase(encryption_happens_only_when_secret_available, Config) ->
+    ok = application:set_env(credentials_obfuscation, enabled, true),
     Config;
 init_per_testcase(change_default_cipher, Config) ->
     %% use weak cipher, to avoid collision with defaults
@@ -55,6 +55,8 @@ init_per_testcase(application_failure_for_invalid_cipher, Config) ->
     Config;
 init_per_testcase(_TestCase, Config) ->
     {ok, _} = application:ensure_all_started(credentials_obfuscation),
+    Secret = crypto:strong_rand_bytes(128),
+    ok = credentials_obfuscation:set_secret(Secret),
     Config.
 
 end_per_testcase(_TestCase, Config) ->
@@ -75,10 +77,13 @@ encrypt_decrypt(_Config) ->
     ok.
 
 use_predefined_secret(_Config) ->
-    ?assertEqual(<<"credentials-obfuscation#2">>, credentials_obfuscation_app:secret()),
+    Secret = crypto:strong_rand_bytes(128),
+    ok = credentials_obfuscation:set_secret(Secret),
+    ?assertEqual(Secret, credentials_obfuscation:secret()),
     ok.
 
 use_cookie_as_secret(_Config) ->
+    _ = net_kernel:stop(),
     ?assertEqual(nocookie, erlang:get_cookie()),
 
     %% Start epmd
@@ -89,19 +94,20 @@ use_cookie_as_secret(_Config) ->
     ?assertNotEqual(nocookie, Cookie),
     {ok, _} = application:ensure_all_started(credentials_obfuscation),
     CookieBin = atom_to_binary(Cookie, utf8),
-    ?assertEqual(CookieBin, credentials_obfuscation_app:secret()),
+    ok = credentials_obfuscation:set_secret(CookieBin),
+    ?assertEqual(CookieBin, credentials_obfuscation:secret()),
     ok = net_kernel:stop(),
     ok.
 
-encryption_happens_only_when_cookie_available(_Config) ->
+encryption_happens_only_when_secret_available(_Config) ->
     _ = net_kernel:stop(),
     Uri = <<"amqp://super:secret@localhost:5672">>,
     {ok, _} = application:ensure_all_started(credentials_obfuscation),
 
     ?assertEqual(nocookie, erlang:get_cookie()),
 
-    ?assert(credentials_obfuscation_app:enabled()),
-    ?assertEqual('$pending-secret', credentials_obfuscation_app:secret()),
+    ?assert(credentials_obfuscation:enabled()),
+    ?assertEqual('$pending-secret', credentials_obfuscation:secret()),
 
     NotReallyEncryptedUri = credentials_obfuscation:encrypt(Uri),
     ?assertEqual({plaintext, Uri}, NotReallyEncryptedUri),
@@ -116,7 +122,8 @@ encryption_happens_only_when_cookie_available(_Config) ->
     ?assertNotEqual(nocookie, Cookie),
 
     CookieBin = atom_to_binary(Cookie, utf8),
-    ?assertEqual(CookieBin, credentials_obfuscation_app:secret()),
+    ok = credentials_obfuscation:set_secret(CookieBin),
+    ?assertEqual(CookieBin, credentials_obfuscation:secret()),
 
     EncryptedUri = credentials_obfuscation:encrypt(Uri),
     {encrypted, _} = EncryptedUri,
@@ -126,9 +133,9 @@ encryption_happens_only_when_cookie_available(_Config) ->
     ok.
 
 change_default_cipher(_Config) ->
-    ?assertNotEqual(credentials_obfuscation_pbe:default_cipher(), credentials_obfuscation_app:cipher()),
-    ?assertNotEqual(credentials_obfuscation_pbe:default_hash(), credentials_obfuscation_app:hash()),
-    ?assertNotEqual(credentials_obfuscation_pbe:default_iterations(), credentials_obfuscation_app:iterations()),
+    ?assertNotEqual(credentials_obfuscation_pbe:default_cipher(), credentials_obfuscation:cipher()),
+    ?assertNotEqual(credentials_obfuscation_pbe:default_hash(), credentials_obfuscation:hash()),
+    ?assertNotEqual(credentials_obfuscation_pbe:default_iterations(), credentials_obfuscation:iterations()),
     Credentials = <<"guest">>,
     Encrypted = credentials_obfuscation:encrypt(Credentials),
     ?assertNotEqual(Credentials, Encrypted),
@@ -136,12 +143,12 @@ change_default_cipher(_Config) ->
     ok.
 
 disabled(_Config) ->
-    ?assertNot(credentials_obfuscation_app:enabled()),
+    ?assertNot(credentials_obfuscation:enabled()),
     Credentials = <<"guest">>,
     ?assertEqual(Credentials, credentials_obfuscation:encrypt(Credentials)),
     ?assertEqual(Credentials, credentials_obfuscation:decrypt(Credentials)),
     ok.
 
 application_failure_for_invalid_cipher(_Config) ->
-    {error, _ } = application:ensure_all_started(credentials_obfuscation),
+    {error, _} = application:ensure_all_started(credentials_obfuscation),
     ok.


### PR DESCRIPTION
Use of the library has changed so that end-users are required to set the secret at some point after the application is started. This allows RabbitMQ to set the secret to the cookie after distribution is started.

Removes the use of an ETS table in favor of gen_server state.