### PR TITLE
Handle encryption service call timeouts gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,35 @@ the Erlang runtime (`error_logger`).
 Note that this application **cannot protect against heap dumping attacks** and only helps
 avoid sensitive data appearing in log files.
 
-# Usage
+## Usage
 
 First, make the `credentials_obfuscation` application a dependency of your project.
 
-Then, during the start-up of your application, and after the `credentials_obfuscation` application starts, provide the secret value:
+Then, during the start-up of your application, and after the `credentials_obfuscation` application starts,
+provide the secret value:
 
-
-```
+``` erl
 CookieBin = atom_to_binary(erlang:get_cookie(), latin1),
 credentials_obfuscation:set_secret(CookieBin)
 ```
 
 To use a random value, do the following:
 
-```
+``` erl
 Bytes = crypto:strong_rand_bytes(128),
 credentials_obfuscation:set_secret(Bytes)
 ```
+
+To encrypt and decrypt a value:
+
+``` erl
+Encrypted = credentials_obfuscation:encrypt(<<"abc">>).
+% => {encrypted,<<"KdH0bP4CYasbA3X79nKShEJhajQ7D7wz1G4yqJmDS4d7zRuuUhAPuQKxdDVgxQtO">>}
+
+credentials_obfuscation:decrypt(Encrypted).
+% => <<"abc">>
+```
+
 
 ## License and Copyright
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then, during the start-up of your application, and after the `credentials_obfusc
 
 
 ```
-CookieBin = atom_to_binary(erlang:get_cookie(), latin1)),
+CookieBin = atom_to_binary(erlang:get_cookie(), latin1),
 credentials_obfuscation:set_secret(CookieBin)
 ```
 


### PR DESCRIPTION
Not handling them can expose the original unencrypted value in
a runtime exception log entry (a crash report).

However, this decision comes with an important trade-off covered
below.

We treat timeouts the same way we do other "encrypting was not possible"
scenarios: return the original value. This won't be acceptable to every user
but might be to some. There is no right or wrong answer to whether
availability or security are more important, so the users have to decide
whether using {plaintext, Term} results is appropriate in their specific case.
If it's not then `{plaintext, Term}` responses should be treated as errors.

In RabbitMQ's specific case the risk is credential exposure in a very specific,
unlikely case, or reduced availability for client connections in the same case.