### PR TITLE
Support encryption of cleartext char list values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bytes = crypto:strong_rand_bytes(128),
 credentials_obfuscation:set_secret(Bytes)
 ```
 
-To encrypt and decrypt a value:
+To encrypt and decrypt a binary or list value:
 
 ``` erl
 Encrypted = credentials_obfuscation:encrypt(<<"abc">>).
@@ -38,7 +38,6 @@ Encrypted = credentials_obfuscation:encrypt(<<"abc">>).
 credentials_obfuscation:decrypt(Encrypted).
 % => <<"abc">>
 ```
-
 
 ## License and Copyright
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ credentials_obfuscation:decrypt(Encrypted).
 % => <<"abc">>
 ```
 
+Lists (char lists in Elixir) will be converted to binaries before encryption.
+This means that decrypted values will also be returned as binaries.
+
 ## License and Copyright
 
 See [LICENSE](./LICENSE).

--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -99,6 +99,8 @@ decrypt_term(Cipher, Hash, Iterations, Secret, Base64Binary) ->
               pos_integer(), iodata() | '$pending-secret', binary()) -> {plaintext, binary()} | {encrypted, binary()}.
 encrypt(_Cipher, _Hash, _Iterations, ?PENDING_SECRET, ClearText) ->
     {plaintext, ClearText};
+encrypt(Cipher, Hash, Iterations, Secret, ClearText) when is_list(ClearText) ->
+    encrypt(Cipher, Hash, Iterations, Secret, list_to_binary(ClearText));
 encrypt(Cipher, Hash, Iterations, Secret, ClearText) when is_binary(ClearText) ->
     Salt = crypto:strong_rand_bytes(16),
     Ivec = crypto:strong_rand_bytes(iv_length(Cipher)),

--- a/test/credentials_obfuscation_SUITE.erl
+++ b/test/credentials_obfuscation_SUITE.erl
@@ -12,6 +12,7 @@
 -compile(export_all).
  
 all() -> [encrypt_decrypt,
+          encrypt_decrypt_char_list_value,
           use_predefined_secret,
           use_cookie_as_secret,
           encryption_happens_only_when_secret_available,
@@ -70,6 +71,14 @@ encrypt_decrypt(_Config) ->
     Encrypted = credentials_obfuscation:encrypt(Credentials),
     ?assertNotEqual(Credentials, Encrypted),
     ?assertEqual(Credentials, credentials_obfuscation:decrypt(Encrypted)),
+    ok.
+
+encrypt_decrypt_char_list_value(_Config) ->
+    Credentials = "guest",
+    Expected = <<"guest">>,
+    Encrypted = credentials_obfuscation:encrypt(Credentials),
+    ?assertNotEqual(Expected, Encrypted),
+    ?assertEqual(Expected, credentials_obfuscation:decrypt(Encrypted)),
     ok.
 
 use_predefined_secret(_Config) ->


### PR DESCRIPTION
By converting them to binary.

When it comes to credentials, the two data types are usually semantically equivalent. When this is not the case, simply
use binaries across the board.