### PR TITLE
Balance security and performance

### DIFF
--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -21,9 +21,9 @@
 -endif.
 
 -ifdef(HAS_CRYPTO_INFO_FUNCTIONS).
--define(DEFAULT_CIPHER, aes_256_cbc).
+-define(DEFAULT_CIPHER, aes_128_cbc).
 -else.
--define(DEFAULT_CIPHER, aes_cbc256).
+-define(DEFAULT_CIPHER, aes_cbc128).
 -endif.
 
 %% Supported ciphers and hashes
@@ -70,10 +70,10 @@ default_cipher() ->
     ?DEFAULT_CIPHER.
 
 default_hash() ->
-    sha512.
+    sha256.
 
 default_iterations() ->
-    1000.
+    1.
 
 %% Encryption/decryption of arbitrary Erlang terms.
 


### PR DESCRIPTION
1000 iterations seems a bit excessive for simply obfuscating
credentials, with these new default MQTT connections can be opened at a
rate of 800 connections/s instead of 8 connections/s.