### PR TITLE
Support Erlang/OTP-24

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "21.3"}.
+{minimum_otp_vsn, "22.1"}.
 {erl_opts, []}.
 {deps, []}.
 

--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -13,9 +13,15 @@
 -export([encrypt_term/5, decrypt_term/5]).
 -export([encrypt/5, decrypt/5]).
 
+
 %% Supported ciphers and hashes
 
 %% We only support block ciphers that use an initialization vector.
+
+%% AEAD ciphers expect Associated Data (AD), which we don't have. It would be
+%% convenient if there was a way to get this list rather than hardcode it:
+%% https://bugs.erlang.org/browse/ERL-1479.
+-define(AEAD_CIPHERS, [aes_gcm, aes_ccm, chacha20_poly1305]).
 
 supported_ciphers() ->
     SupportedByCrypto = crypto:supports(ciphers),
@@ -23,7 +29,7 @@ supported_ciphers() ->
         Mode = maps:get(mode, crypto:cipher_info(Cipher)),
         not lists:member(Mode, [ccm_mode, ecb_mode, gcm_mode])
     end,
-    SupportedByCrypto).
+    SupportedByCrypto) -- ?AEAD_CIPHERS.
 
 supported_hashes() ->
     crypto:supports(hashs).

--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -13,22 +13,7 @@
 -export([encrypt_term/5, decrypt_term/5]).
 -export([encrypt/5, decrypt/5]).
 
-%% A lot of ugly code in this module can be removed once we support OTP-22+.
--ifdef(OTP_RELEASE).
--if(?OTP_RELEASE >= 22).
--define(HAS_CRYPTO_INFO_FUNCTIONS, 1).
--endif.
--endif.
-
--ifdef(HAS_CRYPTO_INFO_FUNCTIONS).
--define(DEFAULT_CIPHER, aes_128_cbc).
--else.
--define(DEFAULT_CIPHER, aes_cbc128).
--endif.
-
 %% Supported ciphers and hashes
-
--ifdef(HAS_CRYPTO_INFO_FUNCTIONS).
 
 %% We only support block ciphers that use an initialization vector.
 
@@ -45,29 +30,12 @@ supported_ciphers() ->
     end,
     SupportedByCrypto).
 
--else.
-
-supported_ciphers() ->
-    NotSupportedByUs = [aes_ccm, aes_128_ccm, aes_192_ccm, aes_256_ccm,
-                        aes_gcm, aes_128_gcm, aes_192_gcm, aes_256_gcm,
-                        aes_ecb, aes_128_ecb, aes_192_ecb, aes_256_ecb,
-                        aes_ctr, aes_128_ctr, aes_192_ctr, aes_256_ctr,
-                        chacha20, chacha20_poly1305,
-                        blowfish_ecb, des_ecb, rc4],
-    SupportedByCrypto = proplists:get_value(ciphers, crypto:supports()),
-    lists:filter(fun(Cipher) ->
-        not lists:member(Cipher, NotSupportedByUs)
-    end,
-    SupportedByCrypto).
-
--endif.
-
 supported_hashes() ->
     proplists:get_value(hashs, crypto:supports()).
 
 %% Default encryption parameters.
 default_cipher() ->
-    ?DEFAULT_CIPHER.
+    aes_128_cbc.
 
 default_hash() ->
     sha256.
@@ -146,8 +114,6 @@ unpad(Data) ->
     N = binary:last(Data),
     binary:part(Data, 0, byte_size(Data) - N).
 
--ifdef(HAS_CRYPTO_INFO_FUNCTIONS).
-
 hash_length(Type) ->
     maps:get(size, crypto:hash_info(Type)).
 
@@ -159,92 +125,6 @@ key_length(Type) ->
 
 block_size(Type) ->
     maps:get(block_size, crypto:cipher_info(Type)).
-
--else.
-
-hash_length(md4) -> 16;
-hash_length(md5) -> 16;
-hash_length(ripemd160) -> 20;
-hash_length(sha) -> 20;
-hash_length(sha224) -> 28;
-hash_length(sha3_224) -> 28;
-hash_length(sha256) -> 32;
-hash_length(sha3_256) -> 32;
-hash_length(sha384) -> 48;
-hash_length(sha3_384) -> 48;
-hash_length(sha512) -> 64;
-hash_length(sha3_512) -> 64;
-hash_length(blake2b) -> 64;
-hash_length(blake2s) -> 32.
-
-iv_length(des_cbc) -> 8;
-iv_length(des_cfb) -> 8;
-iv_length(des3_cbc) -> 8;
-iv_length(des3_cbf) -> 8;
-iv_length(des3_cfb) -> 8;
-iv_length(des_ede3) -> 8;
-iv_length(des_ede3_cbf) -> 8;
-iv_length(des_ede3_cfb) -> 8;
-iv_length(des_ede3_cbc) -> 8;
-iv_length(blowfish_cbc) -> 8;
-iv_length(blowfish_cfb64) -> 8;
-iv_length(blowfish_ofb64) -> 8;
-iv_length(rc2_cbc) -> 8;
-iv_length(aes_cbc) -> 16;
-iv_length(aes_cbc128) -> 16;
-iv_length(aes_cfb8) -> 16;
-iv_length(aes_cfb128) -> 16;
-iv_length(aes_cbc256) -> 16;
-iv_length(aes_128_cbc) -> 16;
-iv_length(aes_192_cbc) -> 16;
-iv_length(aes_256_cbc) -> 16;
-iv_length(aes_128_cfb8) -> 16;
-iv_length(aes_192_cfb8) -> 16;
-iv_length(aes_256_cfb8) -> 16;
-iv_length(aes_128_cfb128) -> 16;
-iv_length(aes_192_cfb128) -> 16;
-iv_length(aes_256_cfb128) -> 16;
-iv_length(aes_ige256) -> 32.
-
-key_length(des_cbc) -> 8;
-key_length(des_cfb) -> 8;
-key_length(des3_cbc) -> 24;
-key_length(des3_cbf) -> 24;
-key_length(des3_cfb) -> 24;
-key_length(des_ede3) -> 24;
-key_length(des_ede3_cbf) -> 24;
-key_length(des_ede3_cfb) -> 24;
-key_length(des_ede3_cbc) -> 24;
-key_length(blowfish_cbc) -> 16;
-key_length(blowfish_cfb64) -> 16;
-key_length(blowfish_ofb64) -> 16;
-key_length(rc2_cbc) -> 16;
-key_length(aes_cbc) -> 16;
-key_length(aes_cbc128) -> 16;
-key_length(aes_cfb8) -> 16;
-key_length(aes_cfb128) -> 16;
-key_length(aes_cbc256) -> 32;
-key_length(aes_128_cbc) -> 16;
-key_length(aes_192_cbc) -> 24;
-key_length(aes_256_cbc) -> 32;
-key_length(aes_128_cfb8) -> 16;
-key_length(aes_192_cfb8) -> 24;
-key_length(aes_256_cfb8) -> 32;
-key_length(aes_128_cfb128) -> 16;
-key_length(aes_192_cfb128) -> 24;
-key_length(aes_256_cfb128) -> 32;
-key_length(aes_ige256) -> 16.
-
-block_size(aes_cbc) -> 16;
-block_size(aes_cbc256) -> 16;
-block_size(aes_cbc128) -> 16;
-block_size(aes_128_cbc) -> 16;
-block_size(aes_192_cbc) -> 16;
-block_size(aes_256_cbc) -> 16;
-block_size(aes_ige256) -> 16;
-block_size(_) -> 8.
-
--endif.
 
 %% The following was taken from OTP's lib/public_key/src/pubkey_pbe.erl
 %%

--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -17,16 +17,11 @@
 
 %% We only support block ciphers that use an initialization vector.
 
-%% @todo ctr_mode ciphers can be supported starting from OTP-22+
-%% without any additional change. stream_cipher ciphers can be
-%% supported starting from OTP-22+ by using the new encrypt/decrypt
-%% functions.
-
 supported_ciphers() ->
     SupportedByCrypto = crypto:supports(ciphers),
     lists:filter(fun(Cipher) ->
         Mode = maps:get(mode, crypto:cipher_info(Cipher)),
-        not lists:member(Mode, [ccm_mode, ctr_mode, ecb_mode, gcm_mode, stream_cipher])
+        not lists:member(Mode, [ccm_mode, ecb_mode, gcm_mode])
     end,
     SupportedByCrypto).
 

--- a/test/credentials_obfuscation_SUITE.erl
+++ b/test/credentials_obfuscation_SUITE.erl
@@ -10,7 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
- 
+
 all() -> [encrypt_decrypt,
           encrypt_decrypt_char_list_value,
           use_predefined_secret,
@@ -40,7 +40,7 @@ init_per_testcase(encryption_happens_only_when_secret_available, Config) ->
     ok = application:set_env(credentials_obfuscation, enabled, true),
     Config;
 init_per_testcase(change_default_cipher, Config) ->
-    ok = application:set_env(credentials_obfuscation, cipher, aes_cbc128),
+    ok = application:set_env(credentials_obfuscation, cipher, aes_256_cbc),
     ok = application:set_env(credentials_obfuscation, hash, sha512),
     ok = application:set_env(credentials_obfuscation, iterations, 100),
     {ok, _} = application:ensure_all_started(credentials_obfuscation),
@@ -63,7 +63,7 @@ end_per_testcase(_TestCase, Config) ->
     end,
     [ok = application:unset_env(credentials_obfuscation, Key) || {Key, _} <- application:get_all_env(credentials_obfuscation)],
     Config.
- 
+
 encrypt_decrypt(_Config) ->
     Credentials = <<"guest">>,
     Encrypted = credentials_obfuscation:encrypt(Credentials),

--- a/test/credentials_obfuscation_pbe_SUITE.erl
+++ b/test/credentials_obfuscation_pbe_SUITE.erl
@@ -8,17 +8,21 @@
 -module(credentials_obfuscation_pbe_SUITE).
 -include_lib("common_test/include/ct.hrl").
 -compile(export_all).
- 
+
+%% This cipher is listed as supported on macOS, but doesn't actually work.
+%% OTP bug: https://bugs.erlang.org/browse/ERL-1478
+-define(SKIPPED_CIPHERS, [aes_ige256]).
+
 all() -> [
     encrypt_decrypt,
     encrypt_decrypt_charlist_value,
     encrypt_decrypt_term
 ].
- 
+
 encrypt_decrypt(_Config) ->
     %% Take all available block ciphers.
     Hashes = credentials_obfuscation_pbe:supported_hashes(),
-    Ciphers = credentials_obfuscation_pbe:supported_ciphers(),
+    Ciphers = credentials_obfuscation_pbe:supported_ciphers() -- ?SKIPPED_CIPHERS,
     %% For each cipher, try to encrypt and decrypt data sizes from 0 to 64 bytes
     %% with a random Secret.
     _ = [begin
@@ -36,7 +40,7 @@ encrypt_decrypt(_Config) ->
 
 encrypt_decrypt_charlist_value(_Config) ->
     Hashes = credentials_obfuscation_pbe:supported_hashes(),
-    Ciphers = credentials_obfuscation_pbe:supported_ciphers(),
+    Ciphers = credentials_obfuscation_pbe:supported_ciphers() -- ?SKIPPED_CIPHERS,
     _ = [begin
              Secret = crypto:strong_rand_bytes(16),
              Iterations = rand:uniform(100),
@@ -52,7 +56,7 @@ encrypt_decrypt_charlist_value(_Config) ->
 encrypt_decrypt_term(_Config) ->
     %% Take all available block ciphers.
     Hashes = credentials_obfuscation_pbe:supported_hashes(),
-    Ciphers = credentials_obfuscation_pbe:supported_ciphers(),
+    Ciphers = credentials_obfuscation_pbe:supported_ciphers() -- ?SKIPPED_CIPHERS,
     %% Different Erlang terms to try encrypting.
     DataSet = [
         10000,
@@ -74,4 +78,4 @@ encrypt_decrypt_term(_Config) ->
              Data = credentials_obfuscation_pbe:decrypt_term(C, H, Iterations, Secret, Enc)
          end || H <- Hashes, C <- Ciphers, Data <- DataSet],
     ok.
- 
+


### PR DESCRIPTION
Support the upcoming OTP-24 release.

* Drop compatibility shims for old OTP versions. The new minimum is 22.1.
* Use the new crypto API
* Add support for CTR mode and stream ciphers (except AEAD) - there was a todo in the code suggesting to do this once the library requires 22+.

I filed a couple OTP bugs that would make this code cleaner:
* [Function to list AEAD ciphers ](https://bugs.erlang.org/browse/ERL-1479)
* [Unsupported cipher listed as supported](https://bugs.erlang.org/browse/ERL-1478)