### PR TITLE
Submitted on behalf of @luos: Implement fallback secret

### DIFF
--- a/src/credentials_obfuscation.erl
+++ b/src/credentials_obfuscation.erl
@@ -11,7 +11,7 @@
 -export([enabled/0, cipher/0, hash/0, iterations/0, secret/0]).
 
 %% API
--export([set_secret/1, encrypt/1, decrypt/1, refresh_config/0]).
+-export([set_secret/1, set_fallback_secret/1, encrypt/1, decrypt/1, refresh_config/0]).
 
 -spec enabled() -> boolean().
 enabled() ->
@@ -36,6 +36,11 @@ secret() ->
 -spec set_secret(binary()) -> ok.
 set_secret(Secret) when is_binary(Secret) ->
     ok = credentials_obfuscation_svc:set_secret(Secret).
+
+
+-spec set_fallback_secret(binary()) -> ok.
+set_fallback_secret(Secret) when is_binary(Secret) ->
+    ok = credentials_obfuscation_svc:set_fallback_secret(Secret).
 
 -spec encrypt(term()) -> {plaintext, term()} | {encrypted, binary()}.
 encrypt(none) -> none;


### PR DESCRIPTION
Here I am submitting a PR for a branch from @luos' fork that's under the core team review.
I have participated in discussions around it but authored no code at the time
of submission.

Add possibility to set a secondary secret to be able to migrate between
multiple secret values.

API was kept to be compatible with previous behaviour, ie. strings are
converted to binaries.

Encrypted values are now wrapped to be able to identify when a
decryption failed, as if the secret is invalid, it may succeed and
return junk data.