### PR TITLE
Include rebar3_hex in project_plugins, not plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,4 +22,4 @@
     deprecated_functions
 ]}.
 
-{plugins, [rebar3_hex]}.
+{project_plugins, [rebar3_hex]}.


### PR DESCRIPTION
## Proposed Changes

Moves the rebar3_hex plugin from "plugins" to "project_plugins."  Including the plugin within the "plugin" section means all projects the include credentials-obfuscation as a dependency must also include the rebar3_hex plugin.  Note the [documentation](https://hexdocs.pm/rebar3_hex/readme.html#setup):

> NOTE : Be sure not to add rebar3_hex to the plugins section within a projects rebar3 config as this will become a dependency for others downloading your package from hex.pm

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes issue #22 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
