### PR TITLE
Incorporate unexported crypto types

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: [24, 25, "26.0-rc2"]
+        otp_version: [24, 25, "26.0-rc3"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3

--- a/include/otp_crypto.hrl
+++ b/include/otp_crypto.hrl
@@ -1,0 +1,42 @@
+-type cipher_iv() :: aes_128_cbc
+                   | aes_192_cbc
+                   | aes_256_cbc
+                   | aes_cbc
+
+                   | aes_128_ofb
+                   | aes_192_ofb
+                   | aes_256_ofb
+
+                   | aes_128_cfb128
+                   | aes_192_cfb128
+                   | aes_256_cfb128
+                   | aes_cfb128
+
+                   | aes_128_cfb8
+                   | aes_192_cfb8
+                   | aes_256_cfb8
+                   | aes_cfb8
+
+                   | aes_128_ctr
+                   | aes_192_ctr
+                   | aes_256_ctr
+                   | aes_ctr
+
+                   | blowfish_cbc
+                   | blowfish_cfb64
+                   | blowfish_ofb64
+                   | chacha20
+                   | des_ede3_cbc
+                   | des_ede3_cfb
+
+                   | des_cbc
+                   | des_cfb
+                   | rc2_cbc .
+
+
+-type sha3() :: sha3_224 | sha3_256 | sha3_384 | sha3_512 .
+-type sha3_xof() :: shake128 | shake256 .
+-type blake2() :: blake2b | blake2s .
+-type compatibility_only_hash() :: md5 | md4 .
+-type hash_algorithm() :: crypto:sha1() | crypto:sha2() | sha3() | sha3_xof() | blake2() | ripemd160 | compatibility_only_hash() .
+

--- a/src/credentials_obfuscation_pbe.erl
+++ b/src/credentials_obfuscation_pbe.erl
@@ -8,6 +8,7 @@
 -module(credentials_obfuscation_pbe).
 
 -include("credentials_obfuscation.hrl").
+-include("otp_crypto.hrl").
 
 -export([supported_ciphers/0, supported_hashes/0, default_cipher/0, default_hash/0, default_iterations/0]).
 -export([encrypt_term/5, decrypt_term/5]).
@@ -64,7 +65,7 @@ decrypt_term(Cipher, Hash, Iterations, Secret, Base64Binary) ->
 %% The encrypt/5 function returns a base64 binary and the decrypt/5
 %% function accepts that same base64 binary.
 
--spec encrypt(crypto:cipher_iv(), crypto:hash_algorithm(),
+-spec encrypt(cipher_iv(), hash_algorithm(),
               pos_integer(), iodata() | '$pending-secret', iodata()) -> {plaintext, binary()} | {encrypted, binary()}.
 encrypt(_Cipher, _Hash, _Iterations, ?PENDING_SECRET, ClearText) ->
     {plaintext, iolist_to_binary(ClearText)};
@@ -78,7 +79,7 @@ encrypt(Cipher, Hash, Iterations, Secret, ClearText) when is_binary(ClearText) -
     Encrypted = base64:encode(<<Salt/binary, Ivec/binary, Binary/binary>>),
     {encrypted, Encrypted}.
 
--spec decrypt(crypto:cipher_iv(), crypto:hash_algorithm(),
+-spec decrypt(cipher_iv(), hash_algorithm(),
               pos_integer(), iodata(), {'encrypted', binary() | [1..255]} | {'plaintext', _}) -> any().
 decrypt(_Cipher, _Hash, _Iterations, _Secret, {plaintext, ClearText}) ->
     ClearText;


### PR DESCRIPTION
Dialyzer in OTP26 complains about some crypto types that apparently are not exported. We've asked the OTP team to export them: https://github.com/erlang/otp/pull/7103 but it's not clear if/when this will happen.

Therefore, just copy-paste the types to make dialyzer happy.